### PR TITLE
shell: fix assert when bypass mode is set during long-running command

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -969,9 +969,9 @@ static void state_collect(const struct shell *sh)
 			(void)sh->iface->api->read(sh->iface, buf,
 							sizeof(buf), &count);
 			if (count) {
-				z_flag_cmd_ctx_set(sh, true);
+				bool prev_cmd_ctx = z_flag_cmd_ctx_set(sh, true);
 				bypass(sh, buf, count);
-				z_flag_cmd_ctx_set(sh, false);
+				z_flag_cmd_ctx_set(sh, prev_cmd_ctx);
 				/* Check if bypass mode ended. */
 				if (!(volatile shell_bypass_cb_t *)sh->ctx->bypass) {
 					state_set(sh, SHELL_STATE_ACTIVE);


### PR DESCRIPTION
Restore previous command context after bypass function is called. If using shell_set_bypass()/shell_process() (i.e. to detect Control-C) during a long-running shell command, shell_fprintf() would assert after the first shell_process() call. This fixes that ASSERT.