### PR TITLE
Update the Dynon fork of the Zephyr SDK to v3.7.0

### DIFF
--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -42,6 +42,48 @@ LOG_MODULE_REGISTER(net_sock_addr, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #endif
 
+#if defined(CONFIG_DNS_RESOLVER) || defined(CONFIG_NET_IP)
+
+static int getaddrinfo_null_host(int port, const struct zsock_addrinfo *hints,
+				struct zsock_addrinfo *res)
+{
+	if (!hints || !(hints->ai_flags & AI_PASSIVE)) {
+		return DNS_EAI_FAIL;
+	}
+
+	/* For AF_UNSPEC, should we default to IPv6 or IPv4? */
+	if (hints->ai_family == AF_INET || hints->ai_family == AF_UNSPEC) {
+		struct sockaddr_in *addr = net_sin(&res->_ai_addr);
+
+		addr->sin_addr.s_addr = INADDR_ANY;
+		addr->sin_port = htons(port);
+		addr->sin_family = AF_INET;
+		INIT_ADDRINFO(res, addr);
+		res->ai_family = AF_INET;
+	} else if (hints->ai_family == AF_INET6) {
+		struct sockaddr_in6 *addr6 = net_sin6(&res->_ai_addr);
+
+		addr6->sin6_addr = in6addr_any;
+		addr6->sin6_port = htons(port);
+		addr6->sin6_family = AF_INET6;
+		INIT_ADDRINFO(res, addr6);
+		res->ai_family = AF_INET6;
+	} else {
+		return DNS_EAI_FAIL;
+	}
+
+	if (hints->ai_socktype == SOCK_DGRAM) {
+		res->ai_socktype = SOCK_DGRAM;
+		res->ai_protocol = IPPROTO_UDP;
+	} else {
+		res->ai_socktype = SOCK_STREAM;
+		res->ai_protocol = IPPROTO_TCP;
+	}
+	return 0;
+}
+
+#endif
+
 #if defined(CONFIG_DNS_RESOLVER)
 
 struct getaddrinfo_state {
@@ -177,42 +219,6 @@ again:
 	}
 
 	return st;
-}
-
-static int getaddrinfo_null_host(int port, const struct zsock_addrinfo *hints,
-				struct zsock_addrinfo *res)
-{
-	if (!hints || !(hints->ai_flags & AI_PASSIVE)) {
-		return DNS_EAI_FAIL;
-	}
-
-	/* For AF_UNSPEC, should we default to IPv6 or IPv4? */
-	if (hints->ai_family == AF_INET || hints->ai_family == AF_UNSPEC) {
-		struct sockaddr_in *addr = net_sin(&res->_ai_addr);
-		addr->sin_addr.s_addr = INADDR_ANY;
-		addr->sin_port = htons(port);
-		addr->sin_family = AF_INET;
-		INIT_ADDRINFO(res, addr);
-		res->ai_family = AF_INET;
-	} else if (hints->ai_family == AF_INET6) {
-		struct sockaddr_in6 *addr6 = net_sin6(&res->_ai_addr);
-		addr6->sin6_addr = in6addr_any;
-		addr6->sin6_port = htons(port);
-		addr6->sin6_family = AF_INET6;
-		INIT_ADDRINFO(res, addr6);
-		res->ai_family = AF_INET6;
-	} else {
-		return DNS_EAI_FAIL;
-	}
-
-	if (hints->ai_socktype == SOCK_DGRAM) {
-		res->ai_socktype = SOCK_DGRAM;
-		res->ai_protocol = IPPROTO_UDP;
-	} else {
-		res->ai_socktype = SOCK_STREAM;
-		res->ai_protocol = IPPROTO_TCP;
-	}
-	return 0;
 }
 
 int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
@@ -363,8 +369,19 @@ static int try_resolve_literal_addr(const char *host, const char *service,
 	int socktype = SOCK_STREAM;
 	int protocol = IPPROTO_TCP;
 
+	if (service) {
+		port = strtol(service, NULL, 10);
+		if (port < 1 || port > 65535) {
+			return DNS_EAI_NONAME;
+		}
+	}
+
 	if (!host) {
-		return DNS_EAI_NONAME;
+		if (hints->ai_flags & AI_PASSIVE) {
+			return getaddrinfo_null_host(port, hints, res);
+		} else {
+			return DNS_EAI_NONAME;
+		}
 	}
 
 	if (hints) {
@@ -387,12 +404,6 @@ static int try_resolve_literal_addr(const char *host, const char *service,
 		return DNS_EAI_NONAME;
 	}
 
-	if (service) {
-		port = strtol(service, NULL, 10);
-		if (port < 1 || port > 65535) {
-			return DNS_EAI_NONAME;
-		}
-	}
 
 	res->ai_family = resolved_family;
 	res->ai_socktype = socktype;

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -978,9 +978,9 @@ static void state_collect(const struct shell *sh)
 			(void)sh->iface->api->read(sh->iface, buf,
 							sizeof(buf), &count);
 			if (count) {
-				z_flag_cmd_ctx_set(sh, true);
+				bool prev_cmd_ctx = z_flag_cmd_ctx_set(sh, true);
 				bypass(sh, buf, count);
-				z_flag_cmd_ctx_set(sh, false);
+				z_flag_cmd_ctx_set(sh, prev_cmd_ctx);
 				/* Check if bypass mode ended. */
 				if (!(volatile shell_bypass_cb_t *)sh->ctx->bypass) {
 					state_set(sh, SHELL_STATE_ACTIVE);


### PR DESCRIPTION
[Case 393551](https://dynon.fogbugz.com/f/cases/393551/Update-Zephyr-SDK-to-v3-7-0)

- Carry over necessary fixes from `dynon-main-10`.
- Add POSIX support for the following spec:
"_If the AI_PASSIVE bit is set in the ai_flags member of the hints
structure, then the caller plans to use the returned socket address
structure in a call to bind(). In this case, if the nodename
argument is a NULL pointer, then the IP address portion of the socket
address structure will be set to INADDR_ANY for an IPv4 address or
IN6ADDR_ANY_INIT for an IPv6 address._"

