### PR TITLE
drivers: ethernet: stm32: Fix return for eth_stm32_hal_set_config()

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1243,7 +1243,7 @@ static int eth_stm32_hal_set_config(const struct device *dev,
 #if defined(CONFIG_ETH_STM32_MULTICAST_FILTER)
 	case ETHERNET_CONFIG_TYPE_FILTER:
 		eth_stm32_mcast_filter(dev, &config->filter);
-		break;
+		return 0;
 #endif /* CONFIG_ETH_STM32_MULTICAST_FILTER */
 	default:
 		break;


### PR DESCRIPTION
Fixes ` <err> zperf_test: set_mac_filter() failed: -134`.

Verified this commit will evaporate in favor of zephyrproject-rtos/zephyr@17367364541ece74e0c1d09f55b7eff34de11d22 if/when this branch is rebased against 4.2.0.