### PR TITLE
added custom zperf config

### DIFF
--- a/subsys/net/lib/zperf/CMakeLists.txt
+++ b/subsys/net/lib/zperf/CMakeLists.txt
@@ -11,7 +11,7 @@ zephyr_library_sources(
   zperf_tcp_uploader.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_NET_ZPERF_SHELL
+zephyr_library_sources_ifdef(CONFIG_NET_SHELL_ZPERF_SUPPORTED
   zperf_shell.c
 )
 

--- a/subsys/net/lib/zperf/CMakeLists.txt
+++ b/subsys/net/lib/zperf/CMakeLists.txt
@@ -11,7 +11,7 @@ zephyr_library_sources(
   zperf_tcp_uploader.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_NET_SHELL
+zephyr_library_sources_ifdef(CONFIG_NET_ZPERF_SHELL
   zperf_shell.c
 )
 

--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -13,7 +13,7 @@ menuconfig NET_ZPERF
 
 if NET_ZPERF
 
-config NET_ZPERF_SHELL
+config NET_SHELL_ZPERF_SUPPORTED
 	bool "Enables or Disables Shell access to zperf"
 	default y
 	help

--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -13,6 +13,12 @@ menuconfig NET_ZPERF
 
 if NET_ZPERF
 
+config NET_ZPERF_SHELL
+	bool "Enables or Disables Shell access to zperf"
+	default y
+	help
+	  Enables or Disables shell access to zperf.
+
 config ZPERF_WORK_Q_THREAD_PRIORITY
 	int "zperf work queue thread priority"
 	default NUM_PREEMPT_PRIORITIES

--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -239,7 +239,7 @@ static int zperf_init(void)
 
 	zperf_session_init();
 
-	if (IS_ENABLED(CONFIG_NET_ZPERF_SHELL)) {
+	if (IS_ENABLED(CONFIG_NET_SHELL_ZPERF_SUPPORTED)) {
 		zperf_shell_init();
 	}
 

--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -239,7 +239,7 @@ static int zperf_init(void)
 
 	zperf_session_init();
 
-	if (IS_ENABLED(CONFIG_NET_SHELL)) {
+	if (IS_ENABLED(CONFIG_NET_ZPERF_SHELL)) {
 		zperf_shell_init();
 	}
 


### PR DESCRIPTION
Needed to modify the Cmake file in the zperf folder, zperf only has the option to be compiled in, or out.

We needed some of the functionality of zperf, such as the work queue and other setup, but without their shell commands, so that way we could ensure that work only gets submitted and run when Eit mode is **enabled at runtime**, and disabled otherwise. 

Relevant fogbugz cases: 
  [399682](https://dynon.fogbugz.com/f/cases/399682/Conditionally-enable-Zperf)
  [399683](https://dynon.fogbugz.com/f/cases/399683/Enable-ethernet-testing-to-MCU-by-adding-Zperf-thread-to-Switch-and-Servo-FW#BugEvent.2497069)